### PR TITLE
Always produce new-format packets

### DIFF
--- a/openpgp-parser/src/buffer.rs
+++ b/openpgp-parser/src/buffer.rs
@@ -2,11 +2,15 @@
 //! crate on `crates.io`.
 
 #[cfg(not(feature = "std"))]
-use core::mem::size_of;
+extern crate core;
+#[cfg(not(feature = "std"))]
+use self::core::mem;
+
 #[cfg(feature = "std")]
-use std::mem::size_of;
+use self::std::mem;
 #[cfg(feature = "std")]
 extern crate std;
+
 #[cfg(feature = "std")]
 impl From<EOFError> for std::io::Error {
     fn from(_: EOFError) -> Self {
@@ -30,10 +34,10 @@ macro_rules! gen_be_offset {
     ($($(#[$s:meta])* ($i: ident, $t: ty))+) => {$(
         $(#[$s])*
         pub fn $i(&self, offset: usize) -> Result<$t, EOFError> {
-            let range = offset..offset.wrapping_add(size_of::<$t>());
+            let range = offset..offset.wrapping_add(mem::size_of::<$t>());
             let data = self.untrusted_buffer.get(range).ok_or(EOFError)?;
             let mut res: $t = 0;
-            for i in 0..size_of::<$t>() {
+            for i in 0..mem::size_of::<$t>() {
                 res = res << 8 | data[i] as $t
             }
             Ok(res)
@@ -46,10 +50,10 @@ macro_rules! gen_le {
         $(#[$s])*
         #[inline]
         pub fn $i(&mut self) -> Result<$t, EOFError> {
-            let untrusted_buffer = self.get_bytes(size_of::<$t>())?;
+            let untrusted_buffer = self.get_bytes(mem::size_of::<$t>())?;
             let mut res: $t = 0;
-            for i in 0..size_of::<$t>() {
-                res = res << 8 | untrusted_buffer[size_of::<$t>() - 1 - i] as $t
+            for i in 0..mem::size_of::<$t>() {
+                res = res << 8 | untrusted_buffer[mem::size_of::<$t>() - 1 - i] as $t
             }
             Ok(res)
         }
@@ -61,9 +65,9 @@ macro_rules! gen_be {
         $(#[$s])*
         #[inline]
         pub fn $i(&mut self) -> Result<$t, EOFError> {
-            let untrusted_buffer = self.get_bytes(size_of::<$t>())?;
+            let untrusted_buffer = self.get_bytes(mem::size_of::<$t>())?;
             let mut res: $t = 0;
-            for i in 0..size_of::<$t>() {
+            for i in 0..mem::size_of::<$t>() {
                 res = res << 8 | untrusted_buffer[i] as $t
             }
             Ok(res)
@@ -76,11 +80,11 @@ macro_rules! gen_le_offset {
         $(#[$s])*
         #[inline]
         pub fn $i(&self, offset: usize) -> Result<$t, EOFError> {
-            let range = offset..offset.wrapping_add(size_of::<$t>());
+            let range = offset..offset.wrapping_add(mem::size_of::<$t>());
             let data = self.untrusted_buffer.get(range).ok_or(EOFError)?;
             let mut res: $t = 0;
-            for i in 0..size_of::<$t>() {
-                res = res << 8 | data[size_of::<$t>() - 1 - i] as $t
+            for i in 0..mem::size_of::<$t>() {
+                res = res << 8 | data[mem::size_of::<$t>() - 1 - i] as $t
             }
             Ok(res)
         }

--- a/openpgp-parser/src/lib.rs
+++ b/openpgp-parser/src/lib.rs
@@ -10,13 +10,14 @@
     allow(ellipsis_inclusive_range_patterns)
 )]
 #![forbid(missing_docs, unsafe_code, deprecated)]
-// #![deny(warnings)]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(alloc_crate_unstable, feature(alloc))]
 
 #[cfg(any(
     not(any(const_fn_stable, const_fn_unstable)),
     not(any(bare_trait_obj_deprecated, bare_trait_obj_allowed)),
-    not(any(ellipsis_inclusive_range_deprecated, ellipsis_inclusive_range_allowed))
+    not(any(ellipsis_inclusive_range_deprecated, ellipsis_inclusive_range_allowed)),
+    not(any(alloc_crate_stable, alloc_crate_unstable)),
 ))]
 compile_error!("build script bug");
 

--- a/openpgp-parser/src/lib.rs
+++ b/openpgp-parser/src/lib.rs
@@ -73,4 +73,11 @@ pub enum Error {
     NoCreationTime,
     /// Unsupported critical subpacket
     UnsupportedCriticalSubpacket(u8),
+    /// Wrong signature type
+    WrongSignatureType {
+        /// The expected signature type
+        expected_type: signature::SignatureType,
+        /// The actual signature type
+        actual_type: u8,
+    },
 }

--- a/openpgp-parser/src/lib.rs
+++ b/openpgp-parser/src/lib.rs
@@ -5,14 +5,19 @@
 //! will be passed to a different OpenPGP implementation.
 
 #![cfg_attr(bare_trait_obj_deprecated, allow(bare_trait_objects))]
-#![cfg_attr(ellipsis_inclusive_range_deprecated, allow(ellipsis_inclusive_range_patterns))]
+#![cfg_attr(
+    ellipsis_inclusive_range_deprecated,
+    allow(ellipsis_inclusive_range_patterns)
+)]
 #![forbid(missing_docs, unsafe_code, deprecated)]
 // #![deny(warnings)]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 
-#[cfg(any(not(any(const_fn_stable, const_fn_unstable)),
-          not(any(bare_trait_obj_deprecated, bare_trait_obj_allowed)),
-          not(any(ellipsis_inclusive_range_deprecated, ellipsis_inclusive_range_allowed))))]
+#[cfg(any(
+    not(any(const_fn_stable, const_fn_unstable)),
+    not(any(bare_trait_obj_deprecated, bare_trait_obj_allowed)),
+    not(any(ellipsis_inclusive_range_deprecated, ellipsis_inclusive_range_allowed))
+))]
 compile_error!("build script bug");
 
 pub use buffer::{EOFError, Reader};

--- a/openpgp-parser/src/signature.rs
+++ b/openpgp-parser/src/signature.rs
@@ -486,7 +486,7 @@ mod tests {
                 SignatureType::Binary,
             )
             .unwrap_err(),
-            Error::InsecureAlgorithm(OPENPGP_HASH_INSECURE_MD5 as _),
+            Error::InsecureAlgorithm(OPENPGP_HASH_INSECURE_MD5 as _)
         );
         assert_eq!(
             read_signature(
@@ -496,7 +496,7 @@ mod tests {
                 SignatureType::Binary,
             )
             .unwrap_err(),
-            Error::InsecureAlgorithm(OPENPGP_HASH_INSECURE_MD5 as _),
+            Error::InsecureAlgorithm(OPENPGP_HASH_INSECURE_MD5 as _)
         );
     }
     #[test]
@@ -511,7 +511,7 @@ mod tests {
                 SignatureType::Binary,
             )
             .unwrap_err(),
-            Error::UnsupportedHashAlgorithm(255),
+            Error::UnsupportedHashAlgorithm(255)
         );
     }
     #[test]
@@ -526,7 +526,7 @@ mod tests {
                 SignatureType::Binary,
             )
             .unwrap_err(),
-            Error::InsecureAlgorithm(OPENPGP_HASH_INSECURE_SHA1 as _),
+            Error::InsecureAlgorithm(OPENPGP_HASH_INSECURE_SHA1 as _)
         );
         read_signature(
             &mut Reader::new(&s[..]),

--- a/openpgp-parser/src/signature.rs
+++ b/openpgp-parser/src/signature.rs
@@ -48,6 +48,37 @@ pub enum SignatureType {
     Timestamp = 0x40,
 }
 
+/// Rivest-Shamir-Aldeman (RSA) cryptography
+const OPENPGP_PUBLIC_KEY_RSA: u8 = 1;
+
+/// Legacy encrypt-only RSA
+const OPENPGP_PUBLIC_KEY_LEGACY_RSA_ENCRYPT_ONLY: u8 = 2;
+
+/// Legacy sign-only RSA
+const OPENPGP_PUBLIC_KEY_LEGACY_RSA_SIGN_ONLY: u8 = 3;
+
+/// Encrypt-only ElGamal
+const OPENPGP_PUBLIC_KEY_ELGAMAL_ENCRYPT_ONLY: u8 = 16;
+
+/// Finite-field Digital Signature Algorithm (DSA)
+const OPENPGP_PUBLIC_KEY_DSA: u8 = 17;
+
+/// Elliptic-curve Diffe-Hellman
+const OPENPGP_PUBLIC_KEY_ECDH: u8 = 18;
+
+/// Elliptic-curve Digital Signature Algorithm
+const OPENPGP_PUBLIC_KEY_ECDSA: u8 = 19;
+
+/// ElGamal signing and encryption.  This is insecure as ElGamal signatures
+/// have been broken.
+const OPENPGP_PUBLIC_KEY_INSECURE_ELGAMAL_SIGN_ENCRYPT: u8 = 20;
+
+/// Finite-field Diffe-Hellman
+const OPENPGP_PUBLIC_KEY_DH: u8 = 21;
+
+/// Edwards-curve Digital Signature Algorithm
+const OPENPGP_PUBLIC_KEY_EDDSA: u8 = 22;
+
 /// Read a multiprecision integer (MPI) from `reader`.  Value is returned as a
 /// slice.
 pub fn read_mpi<'a>(reader: &mut Reader<'a>) -> Result<&'a [u8], Error> {
@@ -82,18 +113,6 @@ const OPENPGP_HASH_SHA256: i32 = 8;
 const OPENPGP_HASH_SHA384: i32 = 9;
 const OPENPGP_HASH_SHA512: i32 = 10;
 const OPENPGP_HASH_SHA224: i32 = 11;
-
-// Public key algorithms
-const OPENPGP_PUBLIC_KEY_RSA: u8 = 1;
-const OPENPGP_PUBLIC_KEY_LEGACY_RSA_ENCRYPT_ONLY: u8 = 2;
-const OPENPGP_PUBLIC_KEY_LEGACY_RSA_SIGN_ONLY: u8 = 3;
-const OPENPGP_PUBLIC_KEY_ELGAMAL_ENCRYPT_ONLY: u8 = 16;
-const OPENPGP_PUBLIC_KEY_DSA: u8 = 17;
-const OPENPGP_PUBLIC_KEY_ECDH: u8 = 18;
-const OPENPGP_PUBLIC_KEY_ECDSA: u8 = 19;
-const OPENPGP_PUBLIC_KEY_INSECURE_ELGAMAL_SIGN_ENCRYPT: u8 = 20;
-const OPENPGP_PUBLIC_KEY_DH: u8 = 21;
-const OPENPGP_PUBLIC_KEY_EDDSA: u8 = 22;
 
 // Signature subpackets
 const SUBPACKET_CREATION_TIME: u8 = 2;

--- a/openpgp-parser/src/signature.rs
+++ b/openpgp-parser/src/signature.rs
@@ -367,7 +367,7 @@ fn parse_packet_body<'a>(
                 }
             }
         }
-        _ => return Err(Error::IllFormedSignature),
+        _ => return Err(Error::UnsupportedSignatureVersion),
     }
     let mpis = pkey_alg_mpis(pkey_alg, version)?;
     check_hash_algorithm(hash_alg.into(), allow_weak_hashes)?;
@@ -450,6 +450,18 @@ mod tests {
                 assert_eq!(read_mpi(&mut buf).unwrap_err(), Error::BadMPI);
                 assert_eq!(buf.len(), 4);
             }
+        }
+    }
+    #[test]
+    fn wrong_signature_version() {
+        for i in 0u16..256 {
+            let i = i as u8;
+            let e = if i == 3 || i == 4 {
+                Error::PrematureEOF
+            } else {
+                Error::UnsupportedSignatureVersion
+            };
+            assert_eq!(parse_packet_body(&mut Reader::new(&[i]), 0, AllowWeakHashes::No).unwrap_err(), e);
         }
     }
 }

--- a/openpgp-parser/src/signature.rs
+++ b/openpgp-parser/src/signature.rs
@@ -211,7 +211,7 @@ fn process_subpacket<'a>(
         }
         SUBPACKET_SIG_EXPIRATION_TIME => {
             let timestamp = reader.be_u32()?;
-            if time != 0 && timestamp >= time {
+            if time != 0 && timestamp < time {
                 Err(Error::SignatureExpired)
             } else if core::mem::replace(&mut id.expiration_time, Some(timestamp)).is_some() {
                 Err(Error::IllFormedSignature)

--- a/openpgp-parser/src/signature.rs
+++ b/openpgp-parser/src/signature.rs
@@ -370,6 +370,9 @@ fn parse_packet_body<'a>(
         _ => return Err(Error::UnsupportedSignatureVersion),
     }
     let mpis = pkey_alg_mpis(pkey_alg, version)?;
+    if i32::from(hash_alg) == OPENPGP_HASH_INSECURE_MD5 {
+        return Err(Error::InsecureAlgorithm(hash_alg.into()))
+    }
     check_hash_algorithm(hash_alg.into(), allow_weak_hashes)?;
     // Check the creation time
     let creation_time = match siginfo.creation_time {

--- a/openpgp-parser/src/signature.rs
+++ b/openpgp-parser/src/signature.rs
@@ -117,7 +117,7 @@ pub fn pkey_alg_mpis(alg: u8, sig_version: u8) -> Result<u8, Error> {
 }
 
 /// Checks that a hash algorithm is secure; if it is, returns the length (in bytes) of the hash it
-/// generates.  If `allow_weak_hashes` is set, also allow SHA1 and SHA224.
+/// generates.  If `allow_weak_hashes` is set, also allow MD5, SHA1, and SHA224.
 pub fn check_hash_algorithm(hash: i32, allow_weak_hashes: AllowWeakHashes) -> Result<u16, Error> {
     match hash {
         // Okay hash algorithms

--- a/rpm-crypto/src/signatures.rs
+++ b/rpm-crypto/src/signatures.rs
@@ -16,7 +16,12 @@ impl Signature {
     ) -> Result<Self, Error> {
         super::init();
         // Check that the signature is valid
-        let sig_info = signature::parse(untrusted_buffer, time, allow_weak_hashes)?;
+        let sig_info = signature::parse(
+            untrusted_buffer,
+            time,
+            allow_weak_hashes,
+            signature::SignatureType::Binary,
+        )?;
         // We can now pass the buffer to RPM, since it is a valid signature
         let slice = untrusted_buffer;
         let mut params = Signature(std::ptr::null_mut());

--- a/rpm-parser/build.rs
+++ b/rpm-parser/build.rs
@@ -1,5 +1,5 @@
-use std::process;
 use std::env;
+use std::process;
 
 fn main() {
     let rustc = env::var("RUSTC").unwrap();

--- a/rpm-parser/build.rs
+++ b/rpm-parser/build.rs
@@ -13,12 +13,14 @@ fn main() {
     let mut try_from_unstable = false;
     let mut ellipsis_inclusive_range_deprecated = true;
     let mut bare_trait_obj_deprecated = true;
+    let mut alloc_crate_unstable = false;
     if version.starts_with("rustc 1.") {
         let version = &version[8..];
         if let Some(period) = version.find('.') {
             if let Ok(vnum) = version[..period].parse::<u32>() {
                 const_fn_unstable = vnum < 32;
                 try_from_unstable = vnum < 34;
+                alloc_crate_unstable = vnum < 36;
                 bare_trait_obj_deprecated = vnum >= 37;
                 ellipsis_inclusive_range_deprecated = vnum >= 37;
             }
@@ -31,8 +33,6 @@ fn main() {
     }
     if try_from_unstable {
         println!("cargo:rustc-cfg=try_from_unstable");
-        // turn on nightly features on these old compilers
-        println!("cargo:rustc-env=RUSTC_BOOTSTRAP=1");
     } else {
         println!("cargo:rustc-cfg=try_from_stable");
     }
@@ -45,5 +45,12 @@ fn main() {
         println!("cargo:rustc-cfg=ellipsis_inclusive_range_deprecated");
     } else {
         println!("cargo:rustc-cfg=ellipsis_inclusive_range_allowed");
+    }
+    if alloc_crate_unstable {
+        println!("cargo:rustc-cfg=alloc_crate_unstable");
+        // turn on nightly features on these old compilers
+        println!("cargo:rustc-env=RUSTC_BOOTSTRAP=1");
+    } else {
+        println!("cargo:rustc-cfg=alloc_crate_stable");
     }
 }

--- a/rpm-parser/src/header/common.rs
+++ b/rpm-parser/src/header/common.rs
@@ -155,9 +155,11 @@ pub(super) fn load_header<'a>(
                     let r = reader.get_bytes(len).expect("length is in bounds; qed");
                     if is_signature {
                         // All strings in the signature header are printable ASCII
-                        for &i in &r[..len-1] {
+                        for &i in &r[..len - 1] {
                             if i < b' ' || i > 0x7E {
-                                bad_data!("Non-printable-ASCII character in signature header string");
+                                bad_data!(
+                                    "Non-printable-ASCII character in signature header string"
+                                );
                             }
                         }
                         r

--- a/rpm-parser/src/lead.rs
+++ b/rpm-parser/src/lead.rs
@@ -93,7 +93,17 @@ impl RPMLead {
         let signature_type = read_be_u16(&buf[78..80]);
         let mut reserved = [0u8; 16];
         reserved.copy_from_slice(&buf[80..]);
-        Self { magic, major, minor, ty, archnum, name, osnum, signature_type, reserved }
+        Self {
+            magic,
+            major,
+            minor,
+            ty,
+            archnum,
+            name,
+            osnum,
+            signature_type,
+            reserved,
+        }
     }
 }
 

--- a/rpm-parser/src/lib.rs
+++ b/rpm-parser/src/lib.rs
@@ -8,14 +8,19 @@
 
 // #![deny(warnings)]
 #![cfg_attr(bare_trait_obj_deprecated, allow(bare_trait_objects))]
-#![cfg_attr(ellipsis_inclusive_range_deprecated, allow(ellipsis_inclusive_range_patterns))]
+#![cfg_attr(
+    ellipsis_inclusive_range_deprecated,
+    allow(ellipsis_inclusive_range_patterns)
+)]
 #![cfg_attr(const_fn_unstable, feature(const_fn))]
 #![cfg_attr(try_from_unstable, feature(try_from))]
 
-#[cfg(any(not(any(const_fn_stable, const_fn_unstable)),
-          not(any(bare_trait_obj_deprecated, bare_trait_obj_allowed)),
-          not(any(ellipsis_inclusive_range_deprecated, ellipsis_inclusive_range_allowed)),
-          not(any(try_from_stable, try_from_unstable))))]
+#[cfg(any(
+    not(any(const_fn_stable, const_fn_unstable)),
+    not(any(bare_trait_obj_deprecated, bare_trait_obj_allowed)),
+    not(any(ellipsis_inclusive_range_deprecated, ellipsis_inclusive_range_allowed)),
+    not(any(try_from_stable, try_from_unstable))
+))]
 compile_error!("build script bug");
 
 macro_rules! size_of {

--- a/rpm-writer/bin/rpmcanon.rs
+++ b/rpm-writer/bin/rpmcanon.rs
@@ -1,14 +1,18 @@
 #![feature(rustc_private)] // hack hack
 #![feature(libc)]
-
 #![cfg_attr(bare_trait_obj_deprecated, allow(bare_trait_objects))]
-#![cfg_attr(ellipsis_inclusive_range_deprecated, allow(ellipsis_inclusive_range_patterns))]
+#![cfg_attr(
+    ellipsis_inclusive_range_deprecated,
+    allow(ellipsis_inclusive_range_patterns)
+)]
 #![cfg_attr(const_fn_unstable, feature(const_fn))]
 
-#[cfg(any(not(any(const_fn_stable, const_fn_unstable)),
-          not(any(bare_trait_obj_deprecated, bare_trait_obj_allowed)),
-          not(any(ellipsis_inclusive_range_deprecated, ellipsis_inclusive_range_allowed)),
-          not(any(try_from_stable, try_from_unstable))))]
+#[cfg(any(
+    not(any(const_fn_stable, const_fn_unstable)),
+    not(any(bare_trait_obj_deprecated, bare_trait_obj_allowed)),
+    not(any(ellipsis_inclusive_range_deprecated, ellipsis_inclusive_range_allowed)),
+    not(any(try_from_stable, try_from_unstable))
+))]
 compile_error!("build script bug");
 
 extern crate libc;
@@ -80,13 +84,15 @@ fn emit_header(
     hdr.push(
         RPMSIGTAG_SHA1HEADER,
         HeaderEntry::String(
-            CStr::from_bytes_with_nul(&main_header_sha1_hash).expect("RPM NUL-terminates its hex data"),
+            CStr::from_bytes_with_nul(&main_header_sha1_hash)
+                .expect("RPM NUL-terminates its hex data"),
         ),
     );
     hdr.push(
         RPMSIGTAG_SHA256HEADER,
         HeaderEntry::String(
-            CStr::from_bytes_with_nul(&main_header_sha256_hash).expect("RPM NUL-terminates its hex data"),
+            CStr::from_bytes_with_nul(&main_header_sha256_hash)
+                .expect("RPM NUL-terminates its hex data"),
         ),
     );
     hdr.push(RPMSIGTAG_RSAHEADER, HeaderEntry::Bin(&*header_sig));

--- a/rpm-writer/src/lib.rs
+++ b/rpm-writer/src/lib.rs
@@ -4,13 +4,18 @@
 //! the extent possible, instead of using librpm.
 
 #![cfg_attr(bare_trait_obj_deprecated, allow(bare_trait_objects))]
-#![cfg_attr(ellipsis_inclusive_range_deprecated, allow(ellipsis_inclusive_range_patterns))]
+#![cfg_attr(
+    ellipsis_inclusive_range_deprecated,
+    allow(ellipsis_inclusive_range_patterns)
+)]
 #![cfg_attr(const_fn_unstable, feature(const_fn))]
 
-#[cfg(any(not(any(const_fn_stable, const_fn_unstable)),
-          not(any(bare_trait_obj_deprecated, bare_trait_obj_allowed)),
-          not(any(ellipsis_inclusive_range_deprecated, ellipsis_inclusive_range_allowed)),
-          not(any(try_from_stable, try_from_unstable))))]
+#[cfg(any(
+    not(any(const_fn_stable, const_fn_unstable)),
+    not(any(bare_trait_obj_deprecated, bare_trait_obj_allowed)),
+    not(any(ellipsis_inclusive_range_deprecated, ellipsis_inclusive_range_allowed)),
+    not(any(try_from_stable, try_from_unstable))
+))]
 compile_error!("build script bug");
 extern crate rpm_parser;
 use rpm_parser::TagData;


### PR DESCRIPTION
This is RECOMMENDED by RFC4880 and should be supported by all versions
of RPM, as they use the same code for parsing new-format packets that
they use for parsing v4 signature subpackets.

This also fixes a nasty bug in the new-format packet generation code: if
the packet was longer than 8383 bytes, the second byte of the new packet
(0xFF) would be omitted, causing a corrupt packet to be produced.
This would have been misinterpreted by RPM.  Add a test case to ensure
that this does not happen.  Since signatures normally are nowhere near
this long, this bug could have escaped into the wild.