### PR TITLE
Fix serialization of new-format packets

### DIFF
--- a/openpgp-parser/src/packet.rs
+++ b/openpgp-parser/src/packet.rs
@@ -126,6 +126,7 @@ impl<'a> Packet<'a> {
                     let mut v = Vec::with_capacity(6 + len);
                     v.push(tag_byte);
                     v.extend_from_slice(&[
+                        0xFF,
                         (len >> 24) as u8,
                         (len >> 16) as u8,
                         (len >> 8) as u8,


### PR DESCRIPTION
They were previously serialized incorrectly.  This would be a security
risk had the relevant code not been unreachable in the rpmcanon CLI.