### PR TITLE
Serialize all calls to RPM keyring and transaction functions

### DIFF
--- a/rpm-oxide.spec.in
+++ b/rpm-oxide.spec.in
@@ -23,9 +23,9 @@ Vendor:		Invisible Things Lab
 License:	MIT OR Apache-2.0
 URL:		https://www.qubes-os.org
 
-BuildRequires:  rust
+BuildRequires:  rust >= 1.21
 BuildRequires:  cargo
-BuildRequires:  rpm-devel
+BuildRequires:  rpm-devel >= 4.14.2.1-4
 BuildRequires:  rust-debugger-common
 
 Requires:       rpm >= 4.14.2.1-4

--- a/rpm-oxide.spec.in
+++ b/rpm-oxide.spec.in
@@ -44,7 +44,7 @@ RUSTFLAGS='-Cdebuginfo=2 -Clink-arg=-z,relro,-z,now' RUSTC_BOOTSTRAP=1 cargo bui
 install -D -m 0755 -- target/release/rpmcanon "$RPM_BUILD_ROOT"/%{_bindir}/rpmcanon
 
 %check
-RUSTC_BOOTSTRAP=1 cargo test --all-features --release -- --test-threads=1
+RUSTC_BOOTSTRAP=1 cargo test --all-features --release --
 %clean
 rm -rf "$RPM_BUILD_ROOT" '%{name}-%{version}'
 


### PR DESCRIPTION
It turns out that RPM’s keyring and transaction functions are not
thread-safe.  This showed up as crashes in RPM’s atexit() handler when
running the test suite, which were very difficult to debug.  Fix the
problem by wrapping all of these calls in a global lock.  Performance
should not be noticibly impacted, as the hot-path is the symmetric
cryptography and that can still happen in parallel.  rpmcanon is
single-threaded and so is not affected.

Tested by running the test suite several times on a multi-core system.
Without this patch a substantial fraction of runs will crash with
SIGSEGV or SIGABRT.  I cannot reproduce the crash with this patch
applied.