### PR TITLE
Remove a huge amount of unnecessary locking

### DIFF
--- a/rpm-crypto/src/lib.rs
+++ b/rpm-crypto/src/lib.rs
@@ -115,7 +115,6 @@ impl Signature {
         allow_weak_hashes: AllowWeakHashes,
         token: InitToken,
     ) -> Result<Self, Error> {
-        let _mutex = init::grab_mutex(token);
         let sig = RawSignature::parse(untrusted_buffer, time, allow_weak_hashes, token)?;
         let ctx = DigestCtx::init(sig.hash_algorithm(), allow_weak_hashes, token)
             .expect("Digest algorithm already validated");

--- a/rpm-parser/src/verify/mod.rs
+++ b/rpm-parser/src/verify/mod.rs
@@ -192,7 +192,7 @@ mod tests {
     thread_local! {
         static KEYRING: RpmKeyring = {
             let tx = TOKEN.with(|&s|RpmTransactionSet::new(s));
-            tx.keyring()
+            tx.expect("cannot load keyring?").keyring()
         };
         static TOKEN: InitToken = rpm_crypto::init(None);
         static SHA256: DigestCtx = TOKEN.with(|&t|DigestCtx::init(8, openpgp_parser::AllowWeakHashes::No,t))


### PR DESCRIPTION
Panu Matilainen suggested loading the RPM keyring eagerly instead of
lazily.  This turns out to work really well: it gets rid of a potential
late panic and improves thread-safety.

He also mentioned that RPM keyrings are thread-safe and librpm handles
all needed synchronization internally.  A quick look at the 4.14.3
source code indicates that this is in fact the case, and so all of the
synchronization around keyring operations can go away.  As a precaution,
all operations on a transaction set are still serialized against both
each other and process exit.