### PR TITLE
Better error messages for corrupt packages

### DIFF
--- a/rpm-parser/src/verify/mod.rs
+++ b/rpm-parser/src/verify/mod.rs
@@ -180,7 +180,8 @@ pub fn verify_package(
     copy(src, &mut validator)?;
     validator
         .validate(&keyring)
-        .map_err(|()| Error::new(ErrorKind::InvalidData, "Payload forged!"))?;
+        .map_err(|()| Error::new(ErrorKind::InvalidData,
+                                 "Package is corrupt - network problem?"))?;
     Ok(vfy_result)
 }
 


### PR DESCRIPTION
A malicious attacker sending a forged package is the least likely reason
for verification to fail.  The most likely reason is a network problem,
so mention that in the error message.

Fixes QubesOS/qubes-issues#7545.