### PR TITLE
Link against the versioned RPM libraries

### DIFF
--- a/rpm-crypto/src/digests.rs
+++ b/rpm-crypto/src/digests.rs
@@ -20,7 +20,7 @@ extern "C" {
     fn free(ptr: *mut c_void);
 }
 
-#[link(name = "rpmio")]
+#[link(name = ":librpmio.so.9")]
 extern "C" {
     fn rpmDigestLength(tag: c_int) -> usize;
     fn rpmDigestDup(s: *mut ExternDigestCtx) -> DigestCtx;

--- a/rpm-crypto/src/lib.rs
+++ b/rpm-crypto/src/lib.rs
@@ -61,7 +61,7 @@ mod init {
         static RPM_CRYPTO_INIT_ONCE: Once = ONCE_INIT;
         use std::os::raw::{c_char, c_int, c_void};
         use std::ptr;
-        #[link(name = "rpm")]
+        #[link(name = ":librpm.so.9")]
         extern "C" {
             fn rpmReadConfigFiles(file: *const c_char, target: *const c_char) -> c_int;
         }
@@ -70,7 +70,7 @@ mod init {
             fn abort() -> !;
             fn atexit(_: unsafe extern "C" fn()) -> c_int;
         }
-        #[link(name = "rpmio")]
+        #[link(name = ":librpmio.so.9")]
         extern "C" {
             fn rpmPushMacro(
                 mc: *mut c_void,

--- a/rpm-crypto/src/signatures.rs
+++ b/rpm-crypto/src/signatures.rs
@@ -58,7 +58,7 @@ impl Drop for Signature {
     }
 }
 
-#[link(name = "rpmio")]
+#[link(name = ":librpmio.so.9")]
 extern "C" {
     fn pgpPrtParams(pkts: *const u8, pktlen: usize, pkttype: c_uint, ret: &mut Signature) -> c_int;
     fn pgpDigParamsFree(digp: *mut RpmPgpDigParams) -> *mut RpmPgpDigParams;

--- a/rpm-crypto/src/transaction.rs
+++ b/rpm-crypto/src/transaction.rs
@@ -12,7 +12,7 @@ pub struct RpmTransactionSet(*mut Rpmts);
 #[repr(C)]
 pub struct RpmKeyring(*mut RpmKeyring_);
 
-#[link(name = "rpm")]
+#[link(name = ":librpm.so.9")]
 extern "C" {
     fn rpmtsCreate() -> RpmTransactionSet;
     fn rpmKeyringLink(Keyring: *mut RpmKeyring_) -> RpmKeyring;
@@ -72,7 +72,7 @@ impl RpmTransactionSet {
 impl RpmKeyring {
     pub fn validate_sig(&self, sig: Signature) -> Result<(), c_int> {
         let _mutex = grab_mutex(self.token());
-        #[link(name = "rpm")]
+        #[link(name = ":librpm.so.9")]
         extern "C" {
             fn rpmKeyringVerifySig(
                 keyring: *mut RpmKeyring_,

--- a/rpm-parser/src/ffi.rs
+++ b/rpm-parser/src/ffi.rs
@@ -1,7 +1,7 @@
 //! FFI code
 use std::os::raw::c_int;
 
-#[link(name = "rpm")]
+#[link(name = ":librpm.so.9")]
 extern "C" {
     fn rpmTagGetType(tag: c_int) -> c_int;
     fn rpmTagTypeGetClass(tag: c_int) -> c_int;


### PR DESCRIPTION
This guards against breakage due to future librpm ABI changes.