### PR TITLE
Check that i18nstrings are valid and consistent

### DIFF
--- a/rpm-parser/src/header/signature.rs
+++ b/rpm-parser/src/header/signature.rs
@@ -101,6 +101,9 @@ pub fn load_signature(
     let header = {
         let mut cb = |ty: TagType, tag_data: &TagData, body: &[u8]| {
             let tag = tag_data.tag();
+            if tag == 100 || ty == TagType::I18NString {
+                bad_data!("I18Nstring not permitted in signature header");
+            }
             let (_, expected_ty, size, flags, _) =
                 match RPM_SIG_TAGS.binary_search_by_key(&tag, |x| x.0) {
                     Ok(e) => RPM_SIG_TAGS[e],

--- a/rpm-writer/tests/gen_bad_i18ntable.rs
+++ b/rpm-writer/tests/gen_bad_i18ntable.rs
@@ -1,0 +1,133 @@
+extern crate openpgp_parser;
+extern crate rpm_crypto;
+extern crate rpm_parser;
+extern crate rpm_writer;
+use openpgp_parser::signature::AllowWeakHashes;
+use rpm_writer::{HeaderBuilder, HeaderEntry, HeaderKind};
+use std::ffi::CStr;
+const RPMTAG_NAME: u32 = 1000;
+const RPMTAG_VERSION: u32 = 1001;
+const RPMTAG_RELEASE: u32 = 1002;
+const RPMTAG_OS: u32 = 1021;
+const RPMTAG_ARCH: u32 = 1022;
+#[test]
+fn bad_i18ntable_rejected() {
+    let i18nstring1 = vec![
+        CStr::from_bytes_with_nul(b"alpha\0").unwrap(),
+        CStr::from_bytes_with_nul(b"beta\0").unwrap(),
+    ];
+    let i18ntable = vec![
+        CStr::from_bytes_with_nul(b"alpha\0").unwrap(),
+        CStr::from_bytes_with_nul(b"beta\0").unwrap(),
+    ];
+    let i18nstring2 = vec![
+        CStr::from_bytes_with_nul(b"alpha\0").unwrap(),
+        CStr::from_bytes_with_nul(b"beta\0").unwrap(),
+        CStr::from_bytes_with_nul(b"gamma\0").unwrap(),
+    ];
+    let i18nstring3 = vec![CStr::from_bytes_with_nul(b"alpha\0").unwrap()];
+    {
+        let mut main_builder = HeaderBuilder::new(HeaderKind::Main);
+        let name = CStr::from_bytes_with_nul(b"fake_name\0").unwrap();
+        let version = CStr::from_bytes_with_nul(b"fake_version\0").unwrap();
+        let release = CStr::from_bytes_with_nul(b"fake_release\0").unwrap();
+        let os = CStr::from_bytes_with_nul(b"fake_os\0").unwrap();
+        let arch = CStr::from_bytes_with_nul(b"fake_arch\0").unwrap();
+        main_builder.push(RPMTAG_NAME, HeaderEntry::String(name));
+        main_builder.push(RPMTAG_VERSION, HeaderEntry::String(version));
+        main_builder.push(RPMTAG_RELEASE, HeaderEntry::String(release));
+        main_builder.push(RPMTAG_OS, HeaderEntry::String(os));
+        main_builder.push(RPMTAG_ARCH, HeaderEntry::String(arch));
+        main_builder.push(1047, HeaderEntry::I18NTable(&i18nstring1));
+        let mut v: Vec<u8> = vec![];
+        main_builder.emit(&mut v).unwrap();
+        let token = rpm_crypto::init(None);
+        // Debuginfo packages can have an I18Nstring with no I18Ntable
+        rpm_parser::load_immutable(&mut &v[..], token)
+            .expect("Package with no I18NTable incorrectly rejected");
+        main_builder.push(100, HeaderEntry::I18NTable(&i18ntable));
+        v.clear();
+        main_builder.emit(&mut v).unwrap();
+        let bad_table_emsg = rpm_parser::load_immutable(&mut &v[..], token)
+            .map(drop)
+            .unwrap_err()
+            .to_string();
+        assert_eq!(bad_table_emsg, "Invalid I18NTable");
+        main_builder.push(100, HeaderEntry::StringArray(&i18ntable));
+        v.clear();
+        main_builder.emit(&mut v).unwrap();
+        let header = rpm_parser::load_immutable(&mut &v[..], token).unwrap();
+
+        assert_eq!(header.os, "fake_os");
+        assert_eq!(header.name, "fake_name");
+        assert_eq!(header.release, "fake_release");
+        assert_eq!(header.arch, "fake_arch");
+        assert_eq!(header.version, "fake_version");
+        main_builder.push(100, HeaderEntry::StringArray(&i18ntable));
+        main_builder
+            .push(1047, HeaderEntry::I18NTable(&i18nstring2))
+            .unwrap();
+        v.clear();
+        main_builder.emit(&mut v).unwrap();
+        let emsg = rpm_parser::load_immutable(&mut &v[..], token)
+            .map(drop)
+            .unwrap_err()
+            .to_string();
+        assert!(emsg.ends_with("expected 2 but got 3"));
+        assert_eq!(
+            main_builder
+                .push(1047, HeaderEntry::I18NTable(&i18nstring3))
+                .unwrap()
+                .len(),
+            17
+        );
+        v.clear();
+        main_builder.emit(&mut v).unwrap();
+        rpm_parser::load_immutable(&mut &v[..], token)
+            .map(drop)
+            .unwrap();
+        assert_eq!(
+            main_builder
+                .push(1047, HeaderEntry::String(i18nstring3[0]))
+                .unwrap()
+                .len(),
+            6
+        );
+        v.clear();
+        main_builder.emit(&mut v).unwrap();
+        rpm_parser::load_immutable(&mut &v[..], token)
+            .map(drop)
+            .unwrap();
+    }
+}
+
+#[test]
+fn no_i18ntable_in_signature_header() {
+    let i18ntable = &[
+        CStr::from_bytes_with_nul(b"alpha\0").unwrap(),
+        CStr::from_bytes_with_nul(b"beta\0").unwrap(),
+    ];
+    let mut builder = HeaderBuilder::new(HeaderKind::Signature);
+    builder.push(100, HeaderEntry::StringArray(i18ntable));
+    let token = rpm_crypto::init(None);
+    let mut v = vec![];
+    builder.emit(&mut v).unwrap();
+    assert_eq!(
+        rpm_parser::load_signature(&mut &v[..], AllowWeakHashes::No, token)
+            .map(drop)
+            .unwrap_err()
+            .to_string(),
+        "I18Nstring not permitted in signature header"
+    );
+    v.clear();
+    builder = HeaderBuilder::new(HeaderKind::Signature);
+    builder.push(1047, HeaderEntry::I18NTable(i18ntable));
+    builder.emit(&mut v).unwrap();
+    assert_eq!(
+        rpm_parser::load_signature(&mut &v[..], AllowWeakHashes::No, token)
+            .map(drop)
+            .unwrap_err()
+            .to_string(),
+        "I18Nstring not permitted in signature header"
+    );
+}


### PR DESCRIPTION
RPM assumes that the i18ntable is at least as long as all i18nstring
entries, and all released versions may read out of bounds if the
i18ntable is too short.  Reject packages that have any of the following:

- An i18ntable entry or any i18nstring entries in the signature header.
- An i18ntable entry with a type other than RPM_STRING_ARRAY_TYPE,
  which would be unusable.
- An i18nstring entry in the main header that is not preceeded by an
  i18ntable entry.  Due to tag ordering, the i18ntable should always
  preceed any i18nstring entries.
- An i18nstring entry with a greater length than the preceeding
  i18ntable.

However, an i18nstring entry with a smaller length than the preceeding
i18ntable is valid and must be accepted.  This just means that some
translations are missing, which is a valid and legitimate situation.

Tests for all of these cases are included.  The code is also reformatted
with `cargo fmt`.