### PR TITLE
Changes for R4.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,4 @@
 include:
-- file: /r4.0/gitlab-dom0.yml
-  project: QubesOS/qubes-continuous-integration
 - file: /r4.1/gitlab-base.yml
   project: QubesOS/qubes-continuous-integration
 - file: /r4.1/gitlab-dom0.yml

--- a/openpgp-parser/Cargo.toml
+++ b/openpgp-parser/Cargo.toml
@@ -10,3 +10,9 @@ build = "../rpm-parser/build.rs"
 [features]
 std = ["alloc"]
 alloc = []
+bin = []
+
+[[bin]]
+name = "sigparse"
+path = "bin/sigparse.rs"
+required-features = ["bin"]

--- a/openpgp-parser/bin/sigparse.rs
+++ b/openpgp-parser/bin/sigparse.rs
@@ -1,0 +1,23 @@
+extern crate openpgp_parser;
+use openpgp_parser::AllowWeakHashes;
+use openpgp_parser::signature::{parse, SignatureType};
+use std::convert::TryInto;
+use std::fs::File;
+use std::io::{Read, Error, ErrorKind, Result};
+use std::time::{SystemTime, UNIX_EPOCH};
+fn main() -> Result<()> {
+    let mut args = std::env::args_os();
+    if args.next().is_none() {
+        return Ok(());
+    };
+    for i in args {
+        let mut s = File::open(i)?;
+        let mut buf_vec = Vec::new();
+        s.read_to_end(&mut buf_vec)?;
+        let time = SystemTime::now().duration_since(UNIX_EPOCH).expect("Failed to get time")
+            .as_secs();
+        parse(&mut buf_vec, time.try_into().unwrap(), AllowWeakHashes::No, SignatureType::Binary)
+            .or_else(|e| Err(Error::new(ErrorKind::InvalidData, format!("Invalid signature: {:?}", e))))?;
+    }
+    Ok(())
+}

--- a/rpm-oxide.spec.in
+++ b/rpm-oxide.spec.in
@@ -42,6 +42,7 @@ RUSTFLAGS='-Cdebuginfo=2 -Clink-arg=-z,relro,-z,now' RUSTC_BOOTSTRAP=1 cargo bui
 
 %install
 install -D -m 0755 -- target/release/rpmcanon "$RPM_BUILD_ROOT"/%{_bindir}/rpmcanon
+install -D -m 0755 -- target/release/sigparse "$RPM_BUILD_ROOT"/%{_bindir}/sigparse
 
 %check
 RUSTC_BOOTSTRAP=1 cargo test --all-features --release --
@@ -50,6 +51,7 @@ rm -rf "$RPM_BUILD_ROOT" '%{name}-%{version}'
 
 %files
 %attr(755,root,root) %{_bindir}/rpmcanon
+%attr(755,root,root) %{_bindir}/sigparse
 
 %changelog
 @CHANGELOG@

--- a/rpm-parser/src/lead.rs
+++ b/rpm-parser/src/lead.rs
@@ -124,7 +124,7 @@ pub fn read_lead(r: &mut Read) -> Result<RPMLead> {
     let mut seen_nul = false;
     for &i in &lead.name[..] {
         match i {
-            b'A'...b'Z' | b'a'...b'z' | b'.' | b'-' | b'_' | b'+' | b'~' | b':' | b'0'...b'9'
+            b'A'...b'Z' | b'a'...b'z' | b'.' | b'-' | b'_' | b'+' | b'~' | b'^' | b':' | b'0'...b'9'
                 if !seen_nul => {}
             b'\0' => seen_nul = true,
             _ => bad_data!("invalid package name"),


### PR DESCRIPTION
- allow `^` in package name/version, as apparently such packages legitimately exist in Fedora 37
- add CLI tool for openpgp-parser - to be used in fwupd

QubesOS/qubes-issues#6982
QubesOS/qubes-issues#4855