### PR TITLE
Use bindgen instead of manual FFI

### DIFF
--- a/.qubesbuilder
+++ b/.qubesbuilder
@@ -2,6 +2,15 @@ host:
   rpm:
     build:
     - rpm-oxide.spec
+vm-bullseye:
+  deb:
+    build: []
+vm-buster:
+  deb:
+    build: []
+vm-centos-stream8:
+  rpm:
+    build: []
 vm:
   rpm:
     build:

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,4 +1,8 @@
+ifeq ($(filter $(DIST),centos7 centos8 centos-stream8 fc32),)
 RPM_SPEC_FILES := rpm-oxide.spec
+endif
+ifeq ($(filter $(DIST),jessie buster bullseye),)
 DEBIAN_BUILD_DIRS = debian
+endif
 
 # vim: set ft=make:

--- a/debian/control
+++ b/debian/control
@@ -8,9 +8,12 @@ Vcs-Git: https://github.com/QubesOS/qubes-rpm-oxide.git
 Build-Depends:
  rustc,
  cargo,
+ rpm,
  librpm-dev,
  debhelper,
  debhelper-compat (= 12),
+ librust-cc-dev,
+ librust-libc-dev,
 Description: RPM canonicalization and verification tools
 
 Package: qubes-rpm-oxide

--- a/debian/rules
+++ b/debian/rules
@@ -1,15 +1,28 @@
 #!/usr/bin/make -f
 
-export RUSTFLAGS=-Cdebuginfo=2 -Clink-arg=-z,relro,-z,now --remap-path-prefix=$(PWD)=.
+export RUSTFLAGS=-Cdebuginfo=2 -Clink-arg=-Wl,-z,relro,-z,now --remap-path-prefix=$(PWD)=.
 export RUSTC_BOOTSTRAP=1
 
 override_dh_auto_build:
-	cargo build --all-features --release --offline
+	cargo -Zunstable-options \
+		'--config=source.system.directory="/usr/share/cargo/registry"' \
+		'--config=source.crates-io.replace-with="system"' \
+		--offline \
+		build --all-features --release
+
+override_dh_auto_test:
+	cargo -Zunstable-options \
+		'--config=source.system.directory="/usr/share/cargo/registry"' \
+		'--config=source.crates-io.replace-with="system"' \
+		--offline \
+		test --all-features --release
 
 override_dh_auto_install:
 	dh_auto_install
 	install -D -m 0755 -- target/release/rpmcanon \
 		debian/qubes-rpm-oxide/usr/bin/rpmcanon
+	install -D -m 0755 -- target/release/sigparse \
+		debian/qubes-rpm-oxide/usr/bin/sigparse
 
 override_dh_auto_clean:
 	cargo clean

--- a/openpgp-parser/bin/sigparse.rs
+++ b/openpgp-parser/bin/sigparse.rs
@@ -1,9 +1,9 @@
 extern crate openpgp_parser;
-use openpgp_parser::AllowWeakHashes;
 use openpgp_parser::signature::{parse, SignatureType};
+use openpgp_parser::AllowWeakHashes;
 use std::convert::TryInto;
 use std::fs::File;
-use std::io::{Read, Error, ErrorKind, Result};
+use std::io::{Error, ErrorKind, Read, Result};
 use std::time::{SystemTime, UNIX_EPOCH};
 fn main() -> Result<()> {
     let mut args = std::env::args_os();
@@ -14,10 +14,22 @@ fn main() -> Result<()> {
         let mut s = File::open(i)?;
         let mut buf_vec = Vec::new();
         s.read_to_end(&mut buf_vec)?;
-        let time = SystemTime::now().duration_since(UNIX_EPOCH).expect("Failed to get time")
+        let time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Failed to get time")
             .as_secs();
-        parse(&mut buf_vec, time.try_into().unwrap(), AllowWeakHashes::No, SignatureType::Binary)
-            .or_else(|e| Err(Error::new(ErrorKind::InvalidData, format!("Invalid signature: {:?}", e))))?;
+        parse(
+            &mut buf_vec,
+            time.try_into().unwrap(),
+            AllowWeakHashes::No,
+            SignatureType::Binary,
+        )
+        .or_else(|e| {
+            Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("Invalid signature: {:?}", e),
+            ))
+        })?;
     }
     Ok(())
 }

--- a/rpm-crypto/Cargo.toml
+++ b/rpm-crypto/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.2.2"
 authors = ["Demi Marie Obenour <demi@invisiblethingslab.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
+links = "qubes-rpm-lib"
 
 [dependencies]
 openpgp-parser = { version = "0.2.2", path = "../openpgp-parser" }
+
+[build-dependencies]
+cc = "1.0"

--- a/rpm-crypto/build.rs
+++ b/rpm-crypto/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    cc::Build::new()
+        .file("ffi.c")
+        .include("/usr/include")
+        .compile("qubes-rpm-lib");
+    println!("cargo:rerun-if-changed=ffi.c");
+    println!("cargo:rustc-link-lib=dylib=rpm");
+    println!("cargo:rustc-link-lib=dylib=rpmio");
+}

--- a/rpm-crypto/ffi.c
+++ b/rpm-crypto/ffi.c
@@ -1,0 +1,116 @@
+#include <stddef.h>
+#include <stdlib.h>
+#include <rpm/rpmio.h>
+#if defined __has_include
+# if __has_include(<rpm/rpmcrypto.h>)
+#  include <rpm/rpmcrypto.h>
+# endif
+#endif
+#include <rpm/rpmkeyring.h>
+#include <rpm/rpmlib.h>
+#include <rpm/rpmmacro.h>
+#include <rpm/rpmpgp.h>
+#include <rpm/rpmts.h>
+typedef struct DIGEST_CTX_s * DIGEST_CTX;
+
+__attribute__((unused)) static void bogus(void) {
+    (void)rpmDigestDup;
+    (void)rpmDigestLength;
+    (void)rpmDigestInit;
+    (void)rpmDigestUpdate;
+    (void)rpmDigestFinal;
+    (void)rpmReadConfigFiles;
+    (void)rpmPushMacro;
+    (void)pgpPrtParams;
+    (void)pgpDigParamsFree;
+    (void)pgpDigParamsAlgo;
+    (void)rpmtsCreate;
+    (void)rpmtsLink;
+    (void)rpmtsFree;
+    (void)rpmKeyringLink;
+    (void)rpmKeyringFree;
+    (void)rpmtsGetKeyring;
+}
+
+struct DIGEST_CTX_s *qubes_rpm_rpmDigestDup(DIGEST_CTX octx) {
+    return rpmDigestDup(octx);
+}
+size_t qubes_rpm_rpmDigestLength(int hashalgo) {
+    return rpmDigestLength(hashalgo);
+}
+DIGEST_CTX qubes_rpm_rpmDigestInit(int hashalgo, uint32_t flags) {
+    return rpmDigestInit(hashalgo, flags);
+}
+int qubes_rpm_rpmDigestUpdate(DIGEST_CTX ctx, const void *data, size_t len) {
+    return rpmDigestUpdate(ctx, data, len);
+}
+int qubes_rpm_rpmDigestFinal(DIGEST_CTX ctx, void ** datap, size_t * lenp, int asAscii) {
+    return rpmDigestFinal(ctx, datap, lenp, asAscii);
+}
+int qubes_rpm_rpmReadConfigFiles(const char *file, const char *target) {
+    return rpmReadConfigFiles(file, target);
+}
+int qubes_rpm_rpmPushMacro(struct rpmMacroContext_s *mc, const char *n, const char *o, const char *b, int level) {
+    return rpmPushMacro(mc, n, o, b, level);
+}
+int qubes_rpm_pgpPrtParams(const uint8_t *pkts, size_t pktlen, unsigned int pkttype, pgpDigParams *ret) {
+    return pgpPrtParams(pkts, pktlen, pkttype, ret);
+}
+struct pgpDigParams_s *qubes_rpm_pgpDigParamsFree(struct pgpDigParams_s *params) {
+    return pgpDigParamsFree(params);
+}
+unsigned int qubes_rpm_pgpDigParamsAlgo(struct pgpDigParams_s *digp, unsigned int algotype) {
+    return pgpDigParamsAlgo(digp, algotype);
+}
+struct rpmts_s *qubes_rpm_rpmtsCreate(void) {
+    return rpmtsCreate();
+}
+struct rpmts_s *qubes_rpm_rpmtsLink(struct rpmts_s *ts) {
+    return rpmtsLink(ts);
+}
+struct rpmts_s *qubes_rpm_rpmtsFree(struct rpmts_s *ts) {
+    return rpmtsFree(ts);
+}
+struct rpmKeyring_s *qubes_rpm_rpmKeyringLink(struct rpmKeyring_s *keyring) {
+    return rpmKeyringLink(keyring);
+}
+struct rpmKeyring_s *qubes_rpm_rpmKeyringFree(struct rpmKeyring_s *keyring) {
+    return rpmKeyringFree(keyring);
+}
+struct rpmKeyring_s *qubes_rpm_rpmtsGetKeyring(struct rpmts_s *ts, int autoload) {
+    return rpmtsGetKeyring(ts, autoload);
+}
+unsigned int qubes_rpm_rpmTagGetType(unsigned int a) {
+    return rpmTagGetType(a);
+}
+unsigned int qubes_rpm_rpmTagTypeGetClass(unsigned int a) {
+    return rpmTagTypeGetClass(a);
+}
+unsigned int qubes_rpm_rpmKeyringVerifySig(rpmKeyring keyring, pgpDigParams sig, DIGEST_CTX ctx) {
+    return rpmKeyringVerifySig(keyring, sig, ctx);
+}
+
+/* This comes *after* the above definitions, to ensure a compile error if the proper declarations are not visible
+ * in the included headers.  Otherwise the compiler would silently do the wrong thing! */
+rpmRC rpmKeyringVerifySig(struct rpmKeyring_s *keyring, struct pgpDigParams_s *sig, DIGEST_CTX ctx);
+struct DIGEST_CTX_s *rpmDigestDup(DIGEST_CTX octx);
+size_t rpmDigestLength(int hashalgo);
+DIGEST_CTX rpmDigestInit(int hashalgo, uint32_t flags);
+int rpmDigestUpdate(DIGEST_CTX ctx, const void *data, size_t len);
+int rpmDigestFinal(DIGEST_CTX ctx, void ** datap, size_t * lenp, int asAscii);
+int rpmReadConfigFiles(const char *file, const char *target);
+int rpmPushMacro(struct rpmMacroContext_s *mc, const char *n, const char *o, const char *b, int level);
+int pgpPrtParams(const uint8_t *pkts, size_t pktlen, unsigned int pkttype, pgpDigParams *ret);
+struct pgpDigParams_s *pgpDigParamsFree(struct pgpDigParams_s *);
+unsigned int pgpDigParamsAlgo(struct pgpDigParams_s *digp, unsigned int algotype);
+struct rpmts_s *rpmtsCreate(void);
+struct rpmts_s *rpmtsLink(struct rpmts_s *);
+struct rpmts_s *rpmtsFree(struct rpmts_s *);
+struct rpmKeyring_s *rpmKeyringLink(struct rpmKeyring_s *keyring);
+struct rpmKeyring_s *rpmKeyringFree(struct rpmKeyring_s *keyring);
+struct rpmKeyring_s *rpmtsGetKeyring(struct rpmts_s *ts, int autoload);
+#if 0 // the API changed in RPM 4.19 but implicit conversions
+      // allow for compatibility
+enum rpmTagType_e rpmTagGetType(int);
+#endif
+enum rpmTagClass_e rpmTagTypeGetClass(enum rpmTagType_e);

--- a/rpm-crypto/src/lib.rs
+++ b/rpm-crypto/src/lib.rs
@@ -8,7 +8,6 @@
 
 use openpgp_parser::{AllowWeakHashes, Error};
 
-
 mod digests;
 mod signatures;
 pub mod transaction;

--- a/rpm-crypto/src/signatures.rs
+++ b/rpm-crypto/src/signatures.rs
@@ -26,7 +26,7 @@ impl Signature {
         let slice = untrusted_buffer;
         let mut params = Signature(std::ptr::null_mut());
         // SAFETY: we just validated that the signature is well-formed.
-        let r = unsafe { pgpPrtParams(slice.as_ptr(), slice.len(), 2, &mut params) };
+        let r = unsafe { qubes_rpm_pgpPrtParams(slice.as_ptr(), slice.len(), 2, &mut params) };
         assert!(r == 0, "we accepted a signature RPM rejected");
         assert!(!params.0.is_null());
         assert_eq!(params.hash_algorithm(), sig_info.hash_alg);
@@ -37,7 +37,7 @@ impl Signature {
     /// Retrieve the hash algorithm of the signature
     pub fn hash_algorithm(&self) -> u8 {
         // SAFETY: ‘self.0’ is a valid pointer of the type RPM needs
-        let alg = unsafe { pgpDigParamsAlgo(self.0, 9) };
+        let alg = unsafe { qubes_rpm_pgpDigParamsAlgo(self.0, 9) };
         assert!(alg <= 255, "invalid hash algorithm not rejected earlier?");
         alg as _
     }
@@ -45,7 +45,7 @@ impl Signature {
     /// Retrieve the public key algorithm of the signature
     pub fn public_key_algorithm(&self) -> u8 {
         // SAFETY: ‘self.0’ is a valid pointer of the type RPM needs
-        (unsafe { pgpDigParamsAlgo(self.0, 6) }) as _
+        (unsafe { qubes_rpm_pgpDigParamsAlgo(self.0, 6) }) as _
     }
 }
 
@@ -53,14 +53,19 @@ impl Drop for Signature {
     fn drop(&mut self) {
         if !self.0.is_null() {
             // SAFETY: ‘self.0’ is a valid pointer.
-            self.0 = unsafe { pgpDigParamsFree(self.0) }
+            self.0 = unsafe { qubes_rpm_pgpDigParamsFree(self.0) }
         }
     }
 }
 
-#[link(name = "rpmio")]
+#[link(name = "qubes-rpm-lib")]
 extern "C" {
-    fn pgpPrtParams(pkts: *const u8, pktlen: usize, pkttype: c_uint, ret: &mut Signature) -> c_int;
-    fn pgpDigParamsFree(digp: *mut RpmPgpDigParams) -> *mut RpmPgpDigParams;
-    fn pgpDigParamsAlgo(digp: *const RpmPgpDigParams, algotype: c_uint) -> c_uint;
+    fn qubes_rpm_pgpPrtParams(
+        pkts: *const u8,
+        pktlen: usize,
+        pkttype: c_uint,
+        ret: &mut Signature,
+    ) -> c_int;
+    fn qubes_rpm_pgpDigParamsFree(digp: *mut RpmPgpDigParams) -> *mut RpmPgpDigParams;
+    fn qubes_rpm_pgpDigParamsAlgo(digp: *const RpmPgpDigParams, algotype: c_uint) -> c_uint;
 }

--- a/rpm-crypto/src/transaction.rs
+++ b/rpm-crypto/src/transaction.rs
@@ -16,47 +16,47 @@ pub struct RpmKeyring(*mut RpmKeyring_);
 unsafe impl Send for RpmKeyring {}
 unsafe impl Sync for RpmKeyring {}
 
-#[link(name = "rpm")]
+#[link(name = "qubes-rpm-lib")]
 extern "C" {
-    fn rpmtsCreate() -> RpmTransactionSet;
-    fn rpmKeyringLink(Keyring: *mut RpmKeyring_) -> RpmKeyring;
-    fn rpmKeyringFree(Keyring: *mut RpmKeyring_) -> *mut RpmKeyring_;
-    fn rpmtsLink(ts: *mut Rpmts) -> RpmTransactionSet;
-    fn rpmtsFree(ts: *mut Rpmts) -> *mut Rpmts;
-    fn rpmtsGetKeyring(ts: *mut Rpmts, autoload: c_int) -> *mut RpmKeyring_;
+    fn qubes_rpm_rpmtsCreate() -> RpmTransactionSet;
+    fn qubes_rpm_rpmKeyringLink(Keyring: *mut RpmKeyring_) -> RpmKeyring;
+    fn qubes_rpm_rpmKeyringFree(Keyring: *mut RpmKeyring_) -> *mut RpmKeyring_;
+    fn qubes_rpm_rpmtsLink(ts: *mut Rpmts) -> RpmTransactionSet;
+    fn qubes_rpm_rpmtsFree(ts: *mut Rpmts) -> *mut Rpmts;
+    fn qubes_rpm_rpmtsGetKeyring(ts: *mut Rpmts, autoload: c_int) -> *mut RpmKeyring_;
 }
 
 impl Drop for RpmKeyring {
     fn drop(&mut self) {
-        unsafe { rpmKeyringFree(self.0) };
+        unsafe { qubes_rpm_rpmKeyringFree(self.0) };
     }
 }
 
 impl Clone for RpmKeyring {
     fn clone(&self) -> Self {
-        unsafe { rpmKeyringLink(self.0) }
+        unsafe { qubes_rpm_rpmKeyringLink(self.0) }
     }
 }
 
 impl Drop for RpmTransactionSet {
     fn drop(&mut self) {
         let _mutex = grab_mutex(self.token());
-        unsafe { rpmtsFree(self.0) };
+        unsafe { qubes_rpm_rpmtsFree(self.0) };
     }
 }
 
 impl Clone for RpmTransactionSet {
     fn clone(&self) -> Self {
         let _mutex = grab_mutex(self.token());
-        unsafe { rpmtsLink(self.0) }
+        unsafe { qubes_rpm_rpmtsLink(self.0) }
     }
 }
 
 impl RpmTransactionSet {
     pub fn new(token: InitToken) -> Result<Self, ()> {
         let _mutex = grab_mutex(token);
-        let v = unsafe { rpmtsCreate() };
-        let keyring = RpmKeyring(unsafe { rpmtsGetKeyring(v.0, 1) });
+        let v = unsafe { qubes_rpm_rpmtsCreate() };
+        let keyring = RpmKeyring(unsafe { qubes_rpm_rpmtsGetKeyring(v.0, 1) });
         if keyring.0.is_null() {
             Err(())
         } else {
@@ -65,7 +65,7 @@ impl RpmTransactionSet {
     }
 
     pub fn keyring(&self) -> RpmKeyring {
-        let ptr = unsafe { rpmtsGetKeyring(self.0, 0) };
+        let ptr = unsafe { qubes_rpm_rpmtsGetKeyring(self.0, 0) };
         assert!(
             !ptr.is_null(),
             "keyring should have been autoloaded in new()"
@@ -81,15 +81,15 @@ impl RpmTransactionSet {
 
 impl RpmKeyring {
     pub fn validate_sig(&self, sig: Signature) -> Result<(), c_int> {
-        #[link(name = "rpm")]
+        #[link(name = "qubes-rpm-lib")]
         extern "C" {
-            fn rpmKeyringVerifySig(
+            fn qubes_rpm_rpmKeyringVerifySig(
                 keyring: *mut RpmKeyring_,
                 sig: RawSignature,
                 ctx: DigestCtx,
             ) -> c_int;
         }
-        match unsafe { rpmKeyringVerifySig(self.0, sig.sig, sig.ctx) } {
+        match unsafe { qubes_rpm_rpmKeyringVerifySig(self.0, sig.sig, sig.ctx) } {
             0 => Ok(()),
             e => Err(e),
         }

--- a/rpm-oxide.spec.in
+++ b/rpm-oxide.spec.in
@@ -23,10 +23,16 @@ Vendor:		Invisible Things Lab
 License:	MIT OR Apache-2.0
 URL:		https://www.qubes-os.org
 
-BuildRequires:  rust >= 1.21
+BuildRequires:  rust >= 1.38
 BuildRequires:  cargo
 BuildRequires:  rpm-devel >= 4.14.2.1-4
 BuildRequires:  rust-debugger-common
+BuildRequires:  rust-cc-devel
+BuildRequires:  rust-libc-devel
+%define qubes_cargo RUSTFLAGS='-Cdebuginfo=2 -Clink-arg=-Wl,-z,relro,-z,now' \\\
+   cargo '--config=source.system.directory="/usr/share/cargo/registry"' \\\
+         '--config=source.crates-io.replace-with="system"' \\\
+         --offline
 
 Requires:       rpm >= 4.14.2.1-4
 
@@ -38,16 +44,17 @@ RPM canonicalization and verification tools
 %prep
 %setup -q
 %build
-RUSTFLAGS='-Cdebuginfo=2 -Clink-arg=-z,relro,-z,now' RUSTC_BOOTSTRAP=1 cargo build --all-features --release
+%qubes_cargo build --all-features --release
+
+%check
+%qubes_cargo test --all-features --release
 
 %install
 install -D -m 0755 -- target/release/rpmcanon "$RPM_BUILD_ROOT"/%{_bindir}/rpmcanon
 install -D -m 0755 -- target/release/sigparse "$RPM_BUILD_ROOT"/%{_bindir}/sigparse
 
-%check
-RUSTC_BOOTSTRAP=1 cargo test --all-features --release --
 %clean
-rm -rf "$RPM_BUILD_ROOT" '%{name}-%{version}'
+rm -rf "$RPM_BUILD_ROOT"
 
 %files
 %attr(755,root,root) %{_bindir}/rpmcanon

--- a/rpm-parser/src/ffi.rs
+++ b/rpm-parser/src/ffi.rs
@@ -1,11 +1,6 @@
 //! FFI code
-use std::os::raw::c_int;
-
-#[link(name = "rpm")]
-extern "C" {
-    fn rpmTagGetType(tag: c_int) -> c_int;
-    fn rpmTagTypeGetClass(tag: c_int) -> c_int;
-}
+use rpm_crypto::{qubes_rpm_rpmTagGetType, qubes_rpm_rpmTagTypeGetClass};
+use std::os::raw::c_uint;
 
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -25,7 +20,7 @@ pub fn tag_type(tag: u32) -> Option<(TagType, bool)> {
     if tag > 0x7FFF {
         return None;
     }
-    let ty = unsafe { rpmTagGetType(tag as _) };
+    let ty = unsafe { qubes_rpm_rpmTagGetType(tag as _) };
     let is_array = match ty as u32 & 0xffff_0000 {
         0x10000 => false,
         0x20000 => true,
@@ -57,8 +52,8 @@ pub fn tag_type(tag: u32) -> Option<(TagType, bool)> {
     ))
 }
 
-pub fn tag_class(ty: TagType) -> c_int {
-    unsafe { rpmTagTypeGetClass(ty as _) }
+pub fn tag_class(ty: TagType) -> c_uint {
+    unsafe { qubes_rpm_rpmTagTypeGetClass(ty as _) }
 }
 
 #[cfg(test)]

--- a/rpm-parser/src/lead.rs
+++ b/rpm-parser/src/lead.rs
@@ -124,7 +124,16 @@ pub fn read_lead(r: &mut dyn Read) -> Result<RPMLead> {
     let mut seen_nul = false;
     for &i in &lead.name[..] {
         match i {
-            b'A'..=b'Z' | b'a'..=b'z' | b'.' | b'-' | b'_' | b'+' | b'~' | b'^' | b':' | b'0'..=b'9'
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'.'
+            | b'-'
+            | b'_'
+            | b'+'
+            | b'~'
+            | b'^'
+            | b':'
+            | b'0'..=b'9'
                 if !seen_nul => {}
             b'\0' => seen_nul = true,
             _ => bad_data!("invalid package name"),

--- a/rpm-writer/Cargo.toml
+++ b/rpm-writer/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 rpm-parser = { version = "0.2.2", path = "../rpm-parser" }
 rpm-crypto = { version = "0.2.2", path = "../rpm-crypto" }
 openpgp-parser = { version = "0.2.2", path = "../openpgp-parser" }
+libc = "0.2"
 
 [features]
 bin = []

--- a/rpm-writer/bin/rpmcanon.rs
+++ b/rpm-writer/bin/rpmcanon.rs
@@ -1,8 +1,4 @@
-#![feature(rustc_private)] // hack hack
-#![feature(libc)]
 #![forbid(ellipsis_inclusive_range_patterns, bare_trait_objects)]
-
-extern crate libc;
 
 use openpgp_parser::AllowWeakHashes;
 use rpm_crypto::transaction::{RpmKeyring, RpmTransactionSet};


### PR DESCRIPTION
This ensures that future changes to the librpm and librpmio ABI do not
silently cause undefined behavior.  It found a harmless bug (signed
vs unsigned 32-bit integer) in the hand-written bindings.

Fixes: QubesOS/qubes-issues#8522