### PR TITLE
Fix issue in finding debugsymbols for Fedora 41

### DIFF
--- a/rpm-oxide.spec.in
+++ b/rpm-oxide.spec.in
@@ -29,8 +29,7 @@ BuildRequires:  rpm-devel >= 4.14.2.1-4
 BuildRequires:  rust-debugger-common
 BuildRequires:  rust-cc-devel
 BuildRequires:  rust-libc-devel
-%define qubes_cargo RUSTFLAGS='-Cdebuginfo=2 -Clink-arg=-Wl,-z,relro,-z,now' \\\
-   cargo '--config=source.system.directory="/usr/share/cargo/registry"' \\\
+%define qubes_cargo cargo '--config=source.system.directory="/usr/share/cargo/registry"' \\\
          '--config=source.crates-io.replace-with="system"' \\\
          --offline
 
@@ -43,10 +42,13 @@ RPM canonicalization and verification tools
 
 %prep
 %setup -q
+
 %build
+%set_build_flags
 %qubes_cargo build --all-features --release
 
 %check
+%set_build_flags
 %qubes_cargo test --all-features --release
 
 %install


### PR DESCRIPTION
Build typically fails like:
```
+ /usr/bin/find-debuginfo -j8 --strict-build-id -m -i --build-id-seed 0.2.7-1.fc41 --unique-debug-suffix -0.2.7-1.fc41.x86_64 --unique-debug-src-base qubes-rpm-oxide-0.2.7-1.fc41.x86_64 --run-dwz --dwz-low-mem-die-limit 10000000 --dwz-max-die-limit 110000000 -S debugsourcefiles.list /builddir/build/BUILD/qubes-rpm-oxide-0.2.7
find-debuginfo: starting
Extracting debug info from 2 files
warning: Unsupported auto-load script at offset 0 in section .debug_gdb_scripts
of file /builddir/build/BUILDROOT/qubes-rpm-oxide-0.2.7-1.fc41.x86_64/usr/bin/sigparse.
Use `info auto-load python-scripts [REGEXP]' to list them.
warning: Unsupported auto-load script at offset 0 in section .debug_gdb_scripts
of file /builddir/build/BUILDROOT/qubes-rpm-oxide-0.2.7-1.fc41.x86_64/usr/bin/rpmcanon.
Use `info auto-load python-scripts [REGEXP]' to list them.
Error while writing index for `/builddir/build/BUILDROOT/qubes-rpm-oxide-0.2.7-1.fc41.x86_64/usr/bin/sigparse': No debugging symbols
Error while writing index for `/builddir/build/BUILDROOT/qubes-rpm-oxide-0.2.7-1.fc41.x86_64/usr/bin/rpmcanon': No debugging symbols
gdb-add-index: No index was created for /builddir/build/BUILDROOT/qubes-rpm-oxide-0.2.7-1.fc41.x86_64/usr/bin/sigparse
gdb-add-index: [Was there no debuginfo? Was there already an index?]
gdb-add-index: No index was created for /builddir/build/BUILDROOT/qubes-rpm-oxide-0.2.7-1.fc41.x86_64/usr/bin/rpmcanon
gdb-add-index: [Was there no debuginfo? Was there already an index?]
DWARF-compressing 2 files
dwz: Too few files for multifile optimization
sepdebugcrcfix: Updated 0 CRC32s, 2 CRC32s did match.
Creating .debug symlinks for symlinks to ELF files
find-debuginfo: done
```

https://doc.rust-lang.org/cargo/reference/profiles.html#strip

https://github.com/QubesOS/qubes-issues/issues/9244